### PR TITLE
Remove all formatting/color/bold after color section.

### DIFF
--- a/src/colors.c
+++ b/src/colors.c
@@ -21,5 +21,5 @@ void colors()
     {
 	    printf("\033[1;%dm%s", j, ColorCharacter);
 	}
-	printf("\n");
+	printf("\033[0m\n");
 }


### PR DESCRIPTION
This removes all color after running the color section.
Without it, bold and grey are enabled once I'm back in my shell.