### PR TITLE
remove dynamic allocs

### DIFF
--- a/src/extra_functions.c
+++ b/src/extra_functions.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <sys/utsname.h>
 
-char *get_shell_output(const char *command) // get output of shell command not to use for shell env as it is done by /bin/sh
+char *get_shell_output(const char *command, char *returnOutput) // get output of shell command not to use for shell env as it is done by /bin/sh
 {
     FILE *output = popen(command, "r");
     if (output == NULL)
@@ -16,7 +16,6 @@ char *get_shell_output(const char *command) // get output of shell command not t
     }
     else
     {
-        char *returnOutput = malloc(256);
         const int scanf_return = fscanf(output, "%[^\n]256s", returnOutput);
         pclose(output);
         if (scanf_return == EOF)
@@ -32,12 +31,10 @@ char *get_shell_output(const char *command) // get output of shell command not t
 }
 
 // since this specific part is getting reused a lot I am going to make a function here to not copy paste that much
-char *get_linux_distro()
+char *get_linux_distro(char *oscontent, char *osname)
 {
     struct utsname uts;
     uname(&uts);
-    char *oscontent = malloc(512);
-    char *osname = malloc(512);
     int line = 0;
     FILE *f = fopen("/etc/os-release", "rt");
     if (f == NULL || oscontent == NULL)
@@ -56,7 +53,6 @@ char *get_linux_distro()
             line++;
         }
         fclose(f);
-        free(oscontent);
         if (strncmp(osname, "=", 1) == 0)
         {
             int len = strlen(osname);

--- a/src/include/extra_functions.h
+++ b/src/include/extra_functions.h
@@ -1,7 +1,7 @@
 #ifndef EXTRAFUNCTIONS_DOT_H
 #define EXTRAFUNCTIONS_DOT_H
 
-char *get_shell_output(const char *command);
-char *get_linux_distro();
+char *get_shell_output(const char *command, char *returnOutput);
+char *get_linux_distro(char *oscontent, char *osname);
 
 #endif

--- a/src/logo.c
+++ b/src/logo.c
@@ -27,7 +27,9 @@ void logo()
         if there are \ replace them with \\ in the printf (leaving the comment intact)
         use the macos one as an example
     */
-        char *osname = get_linux_distro();
+				char osname[512];
+				char oscontent[512];
+				get_linux_distro(oscontent, osname);
         // using strncmp as it can define the number of charecters
         if (strncmp(osname, "Gentoo", 6) == 0) 
         {

--- a/src/os.c
+++ b/src/os.c
@@ -13,7 +13,9 @@ void os()
     #ifdef __linux__
 	    struct utsname uts;
 	    uname(&uts);
-		char *osname = get_linux_distro();
+		char osname[512];
+		char oscontent[512];
+		get_linux_distro(oscontent, osname);
     	printf(RED "%s" RESET, "OS: ");
     	printf("%s", osname);
 		printf("%s", " GNU/LINUX");

--- a/src/packages.c
+++ b/src/packages.c
@@ -9,25 +9,27 @@
 void packages()
 {
     #ifdef __linux__
-		char *pkgs;
-		char *osname = get_linux_distro();
+		char pkgs[32];
+		char osname[512];
+		char oscontent[512];
+		get_linux_distro(oscontent, osname);
         if (strncmp(osname, "Gentoo", 6) == 0) 
         {
-			pkgs = get_shell_output("qlist -I | wc -l");
+			get_shell_output("qlist -I | wc -l", pkgs);
 			printf(RED "%s" RESET, "PACKAGES: ");
 			printf("%s (portage)", pkgs);
 			printf("\n");
         }
         else if (strncmp(osname, "Arch", 4) == 0)
 		{
-            pkgs = get_shell_output("pacman -Q | wc -l");
+            get_shell_output("pacman -Q | wc -l", pkgs);
 			printf(RED "%s" RESET, "PACKAGES: ");
 			printf("%s (pacman)", pkgs);
 			printf("\n");
         }
         else if (strncmp(osname, "Debian GNU/Linux", 16) == 0)
         {
-            pkgs = get_shell_output("dpkg -l | tail -n+6 | wc -l");
+            get_shell_output("dpkg -l | tail -n+6 | wc -l", pkgs);
 			printf(RED "%s" RESET, "PACKAGES: ");
 			printf("%s (apt)", pkgs);
 			printf("\n");


### PR DESCRIPTION
Removes all `malloc()` calls and replaces it with static stack allocations.

This could potentially be improved upon by storing `osname` and `oscontent`, then passing them, as required, to the functions which need it.