### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Remove it from the location you have kept the binary in
 ### From source
 
 ```console
-sudo make unintsall
+sudo make uninstall
 ```
 
 ### Package Manager


### PR DESCRIPTION
The uninstall command in the README has a typo and is therefore not working.